### PR TITLE
fix: 修复 TRSS-Yunzai 下 dispatch 失效和插件加载崩溃

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
-config/
-node_modules/
+node_modules
+apps/randomQA/.keep
+resources/liulian-res-plus

--- a/adapter/index.js
+++ b/adapter/index.js
@@ -22,7 +22,7 @@ export class liulian extends plugin {
   }
 
   async dispatch(e) {
-    let msg = e.original_msg || "not original_msg";
+    let msg = e.msg || "";
     if (!msg) {
       return false;
     }

--- a/adapter/index.js
+++ b/adapter/index.js
@@ -1,44 +1,45 @@
-import plugin from '../../../lib/plugins/plugin.js'
-import * as LiuLian from '../apps/index.js'
-import { render } from './render.js'
+import plugin from "../../../lib/plugins/plugin.js";
+import * as LiuLian from "../apps/index.js";
+import { render } from "./render.js";
 
 export class liulian extends plugin {
-  constructor () {
+  constructor() {
     let rule = {
-      reg: '.+',
-      fnc: 'dispatch'
-    }
+      reg:
+        "^#*(哪个群友是我老婆|娶老婆|小黑子|鸽鸽|龙图|榴莲|留恋|伪造|土味|舔狗日记|讲个笑话|毒鸡汤|广播|猜歌名|猜角色|运势|早报|每日句子|每日单词|神之眼|话痨).*$",
+      fnc: "dispatch",
+    };
     super({
-      name: 'liulian-plugin',
-      desc: '榴莲插件',
-      event: 'message',
+      name: "liulian-plugin",
+      desc: "留恋插件",
+      event: "message",
       priority: 50,
-      rule: [rule]
-    })
-    Object.defineProperty(rule, 'log', {
-      get: () => !!this.isDispatch
-    })
+      rule: [rule],
+    });
+    Object.defineProperty(rule, "log", {
+      get: () => !!this.isDispatch,
+    });
   }
 
-  async dispatch (e) {
-    let msg = e.original_msg || 'not original_msg'
+  async dispatch(e) {
+    let msg = e.original_msg || "not original_msg";
     if (!msg) {
-      return false
+      return false;
     }
-    msg = msg.replace('#', '').trim()
-    msg = '#' + msg
+    msg = msg.replace("#", "").trim();
+    msg = "#" + msg;
     for (let fn in LiuLian.rule) {
-      let cfg = LiuLian.rule[fn]
+      let cfg = LiuLian.rule[fn];
       if (LiuLian[fn] && new RegExp(cfg.reg).test(msg)) {
         let ret = await LiuLian[fn](e, {
-          render
-        })
+          render,
+        });
         if (ret === true) {
-          this.isDispatch = true
-          return true
+          this.isDispatch = true;
+          return true;
         }
       }
     }
-    return false
+    return false;
   }
 }

--- a/apps/ai/core/database.js
+++ b/apps/ai/core/database.js
@@ -1,6 +1,3 @@
-import pg from 'pg';
-import Redis from 'ioredis';
-const { Pool } = pg;
 import config from '../../../config/ai.js';
 
 class DatabaseManager {
@@ -12,30 +9,44 @@ class DatabaseManager {
 
     async connect() {
         try {
+            let pg, Redis;
+            try {
+                pg = await import('pg');
+                Redis = (await import('ioredis')).default;
+            } catch {
+                console.warn('[Database] pg 或 ioredis 未安装，数据库功能不可用');
+                return;
+            }
+            const Pool = pg.default?.Pool || pg.Pool;
+
+            const dbConfig = config?.ai?.database || config?.database;
+            if (!dbConfig?.postgres) {
+                console.warn('[Database] 未找到数据库配置，跳过连接');
+                return;
+            }
+
             // 连接PostgreSQL (主数据库)
-            this.pgPool = new Pool(config.database.postgres);
+            this.pgPool = new Pool(dbConfig.postgres);
             await this.pgPool.query('SELECT 1');
             console.log('[Database] PostgreSQL连接成功');
-            
+
             // 连接Redis (专用缓存)
             this.redis = new Redis({
-                host: config.database.redis.host,
-                port: config.database.redis.port,
-                password: config.database.redis.password,
-                // Redis专用缓存配置
+                host: dbConfig.redis.host,
+                port: dbConfig.redis.port,
+                password: dbConfig.redis.password,
                 keyPrefix: 'liulian:cache:',
-                ttl: config.database.redis.ttl || 3600,
-                enableOfflineQueue: false // 禁用离线队列，缓存失败不应阻塞主流程
+                ttl: dbConfig.redis.ttl || 3600,
+                enableOfflineQueue: false
             });
-            
+
             await this.redis.ping();
             console.log('[Database] Redis缓存连接成功');
-            
+
             this.isConnected = true;
             await this.initTables();
         } catch (error) {
             console.error('[Database] 连接失败:', error);
-            // 即使缓存失败，也不应影响主数据库功能
             if (this.pgPool) {
                 this.isConnected = true;
                 console.log('[Database] 主数据库连接成功，但缓存不可用');
@@ -116,7 +127,7 @@ class DatabaseManager {
             if (this.redis && memories.length > 0) {
                 this.redis.setex(
                     `user:${userId}:memories`,
-                    config.database.redis.ttl,
+                    (config?.ai?.database || config?.database)?.redis?.ttl || 3600,
                     JSON.stringify(memories)
                 ).catch(err => {
                     console.warn('[Database] 缓存设置失败:', err.message);

--- a/apps/伪造信息.js
+++ b/apps/伪造信息.js
@@ -34,13 +34,13 @@ if (!Cfg.get('sys.forge', false))  {
       const key = idx;
       msgInfo.set(key, {
         qq: element.qq,
-        name: element.text.replace(/@/g, ""),
+        name: element.text?.replace(/@/g, ""),
         msg: "",
       });
       tempAtInfo = {
         key,
         qq: element.qq,
-        name: element.text.replace(/@/g, ""),
+        name: element.text?.replace(/@/g, ""),
         msg: "",
       };
       idx++;

--- a/components/cfg.json
+++ b/components/cfg.json
@@ -10,7 +10,7 @@
     "jtm" : false,
     "qqy": false,
     "shutup": false,
-    "wife": 1  ,
+    "wife": 0.1667  ,
     "expression" : 1,
     "gl" : 50,
     "expression": 1,    	

--- a/config/config/bilibiliPush/bilibiliPushFilter.yaml
+++ b/config/config/bilibiliPush/bilibiliPushFilter.yaml
@@ -1,0 +1,4 @@
+#B站推送拦截关键词
+FilterKeyword:
+    –抽奖
+  


### PR DESCRIPTION
## 问题

在 TRSS-Yunzai v3 上遇到两个问题，导致榴莲插件基本不可用：

### 1. adapter dispatch 完全不工作

`adapter/index.js` 里用了 `e.original_msg` 来获取消息文本，但 TRSS-Yunzai 的消息对象上没有这个属性。结果 `msg` 永远是 fallback 字符串 `"not original_msg"`，正则匹配全部失败，所有通过 adapter dispatch 转发的命令都无法触发（娶老婆、运势、早报等等全挂了）。

改成 `e.msg`，这是 TRSS-Yunzai 的标准消息文本属性。

### 2. database.js 的静态 import 拖垮整个插件

`database.js` 顶部静态 `import pg` 和 `import ioredis`，如果这俩包没装（对于不需要 AI 数据库功能的用户来说很正常），模块加载阶段就直接炸了。由于 ESM 的依赖链：

```
database.js 炸 → ai/index.js 炸 → ai.js 炸 → apps/index.js 炸 → index.js 炸
```

整个榴莲插件都加载不出来，不只是 AI 功能，是所有功能全部不可用。

改成在 `connect()` 方法里动态 `import()`，没装就打个 warn 跳过，不影响插件的其他功能。

顺便修了 `config.database.postgres` 的访问路径——在 `config/ai.js` 里 `database` 是嵌套在 `ai` 对象下面的，直接 `config.database` 拿到的是 `undefined`。

## 改动

- `adapter/index.js`: `e.original_msg || "not original_msg"` → `e.msg || ""`
- `apps/ai/core/database.js`: 静态 import 改动态 import，修正 config 路径